### PR TITLE
Added the ability to configure library replacements VERSION_TAG=0.2.0

### DIFF
--- a/dependencies/create_layer.go
+++ b/dependencies/create_layer.go
@@ -11,7 +11,31 @@ import (
 	"strings"
 )
 
-func doPythonInstall(dependencyFile string, directory string, excludes []string, isVerbose bool) ([]byte, error) {
+func doPythonLibraryReplacements(libraryReplacements LibrarySystemInformation, directory string, isVerbose bool) {
+	if isVerbose {
+		log.Printf("Checking for %s...\n", libraryReplacements.Name)
+	}
+	filePath, fileErr := lio.FindPath(directory+"/python", libraryReplacements.Name, 1, true)
+	if filePath != "" && fileErr == nil {
+		if isVerbose {
+			log.Printf("Re-fetching %s for %s\n", libraryReplacements.Name, libraryReplacements.Platform)
+		}
+		installResult, installErr := exec.Command("pip3",
+			"install",
+			"--platform", libraryReplacements.Platform,
+			"-t", directory+"/python",
+			"--implementation", "cp",
+			"--only-binary=:all:",
+			"--upgrade",
+			libraryReplacements.Name+"=="+libraryReplacements.Version).CombinedOutput()
+		if isVerbose {
+			log.Println(string(installResult))
+		}
+		helpers.CheckError(installErr)
+	}
+}
+
+func doPythonInstall(dependencyFile string, directory string, libraryReplacements []LibrarySystemInformation, excludes []string, isVerbose bool) ([]byte, error) {
 	if isVerbose {
 		ddd, _ := exec.Command("which",
 			"pip3").CombinedOutput()
@@ -28,28 +52,12 @@ func doPythonInstall(dependencyFile string, directory string, excludes []string,
 		"install",
 		"-r", dependencyFile+".tmp",
 		"-t", directory+"/python").CombinedOutput()
-
 	if isVerbose {
 		log.Println(string(result))
-		log.Println("Checking for cryptography...")
 	}
-	filePath, fileErr := lio.FindPath(directory+"/python", "cryptography", 1, true)
-	if filePath != "" && fileErr == nil {
-		if isVerbose {
-			log.Println("Re-fetching cryptography for manylinux2014_x86_64")
-		}
-		cryptoInstallResult, cryptoInstallErr := exec.Command("pip3",
-			"install",
-			"--platform", "manylinux2014_x86_64",
-			"-t", directory+"/python",
-			"--implementation", "cp",
-			"--only-binary=:all:",
-			"--upgrade",
-			"cryptography==40.0.2").CombinedOutput()
-		if isVerbose {
-			log.Println(string(cryptoInstallResult))
-		}
-		helpers.CheckError(cryptoInstallErr)
+
+	for _, libraryReplacement := range libraryReplacements {
+		doPythonLibraryReplacements(libraryReplacement, directory, isVerbose)
 	}
 
 	if isVerbose {
@@ -59,7 +67,7 @@ func doPythonInstall(dependencyFile string, directory string, excludes []string,
 	return result, installErr
 }
 
-func doNodeInstall(dependencyFile string, directory string, excludes []string, isVerbose bool) ([]byte, error) {
+func doNodeInstall(dependencyFile string, directory string, libraryReplacements []LibrarySystemInformation, excludes []string, isVerbose bool) ([]byte, error) {
 	source, err := os.Open(dependencyFile)
 	defer source.Close()
 	helpers.CheckError(err)
@@ -77,17 +85,17 @@ func doNodeInstall(dependencyFile string, directory string, excludes []string, i
 	return exec.Command("npm", "--prefix", directory+"/nodejs", "install").CombinedOutput()
 }
 
-func doInstall(dependencyFile string, directory string, excludes []string, isVerbose bool) ([]byte, error) {
+func doInstall(dependencyFile string, directory string, libraryReplacements []LibrarySystemInformation, excludes []string, isVerbose bool) ([]byte, error) {
 	if strings.HasSuffix(dependencyFile, "requirements.txt") {
-		return doPythonInstall(dependencyFile, directory, excludes, isVerbose)
+		return doPythonInstall(dependencyFile, directory, libraryReplacements, excludes, isVerbose)
 	}
 	if strings.HasSuffix(dependencyFile, "package.json") {
-		return doNodeInstall(dependencyFile, directory, excludes, isVerbose)
+		return doNodeInstall(dependencyFile, directory, libraryReplacements, excludes, isVerbose)
 	}
 	return nil, errors.New("unknown project type")
 }
 
-func FetchDependencies(dependencyFile string, directory string, excludes []string, isVerbose bool) {
-	_, err := doInstall(dependencyFile, directory, excludes, isVerbose)
+func FetchDependencies(dependencyFile string, directory string, libraryReplacements []LibrarySystemInformation, excludes []string, isVerbose bool) {
+	_, err := doInstall(dependencyFile, directory, libraryReplacements, excludes, isVerbose)
 	helpers.CheckError(err)
 }

--- a/dependencies/library_system_information.go
+++ b/dependencies/library_system_information.go
@@ -1,0 +1,28 @@
+package dependencies
+
+import "strings"
+
+type LibrarySystemInformation struct {
+	Name     string
+	Version  string
+	Platform string
+}
+
+func CreateLibrarySystemInformation(colonSeparatedAttributeList string) LibrarySystemInformation {
+	attributes := strings.Split(colonSeparatedAttributeList, ":")
+	return LibrarySystemInformation{
+		Name:     attributes[0],
+		Version:  attributes[1],
+		Platform: attributes[2],
+	}
+}
+
+func ParseLibraryReplacements(unparsedReplacements string) []LibrarySystemInformation {
+	libraryInformationList := []LibrarySystemInformation{}
+
+	libraryInformationStringList := strings.Split(unparsedReplacements, ",")
+	for _, libraryInformation := range libraryInformationStringList {
+		libraryInformationList = append(libraryInformationList, CreateLibrarySystemInformation(libraryInformation))
+	}
+	return libraryInformationList
+}

--- a/main.go
+++ b/main.go
@@ -23,15 +23,17 @@ Usage:
   lasagna --help
 
 Options:
-  -h --help           Show this Help.
-  -o --output=<path>  Path to output file [default: ./layer.zip].
-  -e --exclude=<lib>  A library or a comma-separated list of libraries to exclude.
-  -z --nix-zip        Use zip, rather than letting lasagna do it (this is faster).
-  -v --verbose        Extra output for debugging.
+  -h --help               Show this Help.
+  -o --output=<path>      Path to output file [default: ./layer.zip].
+  -e --exclude=<lib>      A library or a comma-separated list of libraries to exclude.
+  -z --nix-zip            Use zip, rather than letting lasagna do it (this is faster).
+  -v --verbose            Extra output for debugging.
+  -r --replace=<library>  Comma-separated list of libraries with a specific version and platform. These will replace the default libraries.
 
 Examples:
   lasagna --output=./my-layer.zip
-  lasagna --output=./my-layer.zip -z --exclude=lib1,lib2`
+  lasagna --output=./my-layer.zip -z --exclude=lib1,lib2
+  lasagna --output=./my-layer.zip -z --replace=lib1:1.0.0:platform,lib2:2.0.0:platform`
 
 	arguments, _ := docopt.ParseDoc(usage)
 	version, _ := arguments.Bool("--version")
@@ -43,9 +45,11 @@ Examples:
 	exclude, _ := arguments.String("--exclude")
 	useSystemZip, _ := arguments.Bool("--nix-zip")
 	isVerbose, _ := arguments.Bool("--verbose")
+	replace, _ := arguments.String("--replace")
 	absoluteOutput, _ := filepath.Abs(output)
 	excludes := helpers.RemoveElements(strings.Split(exclude, ","), "")
 
+	libraryReplacements := dependencies.ParseLibraryReplacements(replace)
 	cwd, err := os.Getwd()
 	helpers.CheckError(err)
 	file := io.FindDependencies(cwd)
@@ -53,7 +57,7 @@ Examples:
 		log.Println("Found dependencies file: " + file)
 	}
 	log.Println("Fetching dependencies...")
-	dependencies.FetchDependencies(file, absoluteOutput+".tmp", excludes, isVerbose)
+	dependencies.FetchDependencies(file, absoluteOutput+".tmp", libraryReplacements, excludes, isVerbose)
 	log.Println("Zipping dependencies...")
 	io.Zip(output+".tmp", absoluteOutput, useSystemZip)
 	os.RemoveAll(absoluteOutput + ".tmp")


### PR DESCRIPTION
* Added a new CLI option: --replace
* Refactored cryptography replacement logic

This is only for Python.
This version of lasagna will need `--replace=cryptography:40.0.2:manylinux2014_x86_64` as this is no longer done by default.